### PR TITLE
Using unit abbreviations instead of full name when viewing a recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+composer.phar
+Config/database.php
+Config/core.php
 Config/email.php
 tmp/cache/persistent/*
 !tmp/cache/persistent/empty

--- a/Controller/RecipesController.php
+++ b/Controller/RecipesController.php
@@ -95,7 +95,7 @@ class RecipesController extends AppController {
                             'fields' => array('name')
                         ),
                         'Unit' => array(
-                            'fields' => array('name')
+                            'fields' => array('name', 'abbreviation') //2017-01-23 - added 'abbreviation' to be able to view those in the recipe view.
                         )
                     ),
                     'RelatedRecipe' => array(
@@ -106,7 +106,7 @@ class RecipesController extends AppController {
                                     'fields' => array('name')
                                 ),
                                 'Unit' => array(
-                                    'fields' => array('name')
+                                    'fields' => array('name', 'abbreviation') //2017-01-23 - added 'abbreviation' to be able to view those in the related recipe view.
                                 )
                             )
                         )

--- a/Controller/RecipesController.php
+++ b/Controller/RecipesController.php
@@ -95,7 +95,7 @@ class RecipesController extends AppController {
                             'fields' => array('name')
                         ),
                         'Unit' => array(
-                            'fields' => array('name', 'abbreviation') //2017-01-23 - added 'abbreviation' to be able to view those in the recipe view.
+                            'fields' => array('name', 'abbreviation') 
                         )
                     ),
                     'RelatedRecipe' => array(
@@ -106,7 +106,7 @@ class RecipesController extends AppController {
                                     'fields' => array('name')
                                 ),
                                 'Unit' => array(
-                                    'fields' => array('name', 'abbreviation') //2017-01-23 - added 'abbreviation' to be able to view those in the related recipe view.
+                                    'fields' => array('name', 'abbreviation') 
                                 )
                             )
                         )

--- a/View/Recipes/view.ctp
+++ b/View/Recipes/view.ctp
@@ -157,7 +157,7 @@ if (isset($recipe['Review'])) {
                             $quantity = $recipe['IngredientMapping'][$i]['quantity'];
                             if (isset($scale)) $quantity *= $scale;
                             $quantity = $this->Fraction->toFraction($quantity);
-                            $unit = $recipe['IngredientMapping'][$i]['Unit']['name'];
+                            $unit = $recipe['IngredientMapping'][$i]['Unit']['abbreviation']; //2017-01-23, changed view of unit's 'name' --> 'abbreviation'
                             $ingredientName = $recipe['IngredientMapping'][$i]['Ingredient']['name'];
                             $qualifier = $recipe['IngredientMapping'][$i]['qualifier'];
                             $optional = $recipe['IngredientMapping'][$i]['optional'] ? __('(optional)') : "";
@@ -219,7 +219,7 @@ if (isset($recipe['Review'])) {
                             $quantity = $related['Related']['IngredientMapping'][$i]['quantity'];
                             if (isset($scale)) $quantity *= $scale;
                             $quantity = $this->Fraction->toFraction($quantity);
-                            $unit = $related['Related']['IngredientMapping'][$i]['Unit']['name'];
+                            $unit = $related['Related']['IngredientMapping'][$i]['Unit']['abbreviation'];//2017-01-23, changed view of unit's 'name' --> 'abbreviation'
                             $ingredientName = $related['Related']['IngredientMapping'][$i]['Ingredient']['name']; 
                             echo $quantity . " " . $unit . " " . $ingredientName . "<br/>";
                         }?></pre>

--- a/View/Recipes/view.ctp
+++ b/View/Recipes/view.ctp
@@ -220,7 +220,7 @@ if (isset($recipe['Review'])) {
                             if (isset($scale)) $quantity *= $scale;
                             $quantity = $this->Fraction->toFraction($quantity);
                             $unit = $related['Related']['IngredientMapping'][$i]['Unit']['name'];
-                            $ingredientName = $related['Related']['IngredientMapping'][$i]['Ingredient']['name'];
+                            $ingredientName = $related['Related']['IngredientMapping'][$i]['Ingredient']['name']; 
                             echo $quantity . " " . $unit . " " . $ingredientName . "<br/>";
                         }?></pre>
                 </div>

--- a/View/Recipes/view.ctp
+++ b/View/Recipes/view.ctp
@@ -157,7 +157,7 @@ if (isset($recipe['Review'])) {
                             $quantity = $recipe['IngredientMapping'][$i]['quantity'];
                             if (isset($scale)) $quantity *= $scale;
                             $quantity = $this->Fraction->toFraction($quantity);
-                            $unit = $recipe['IngredientMapping'][$i]['Unit']['abbreviation']; //2017-01-23, changed view of unit's 'name' --> 'abbreviation'
+                            $unit = $recipe['IngredientMapping'][$i]['Unit']['abbreviation']; 
                             $ingredientName = $recipe['IngredientMapping'][$i]['Ingredient']['name'];
                             $qualifier = $recipe['IngredientMapping'][$i]['qualifier'];
                             $optional = $recipe['IngredientMapping'][$i]['optional'] ? __('(optional)') : "";
@@ -219,7 +219,7 @@ if (isset($recipe['Review'])) {
                             $quantity = $related['Related']['IngredientMapping'][$i]['quantity'];
                             if (isset($scale)) $quantity *= $scale;
                             $quantity = $this->Fraction->toFraction($quantity);
-                            $unit = $related['Related']['IngredientMapping'][$i]['Unit']['abbreviation'];//2017-01-23, changed view of unit's 'name' --> 'abbreviation'
+                            $unit = $related['Related']['IngredientMapping'][$i]['Unit']['abbreviation'];
                             $ingredientName = $related['Related']['IngredientMapping'][$i]['Ingredient']['name']; 
                             echo $quantity . " " . $unit . " " . $ingredientName . "<br/>";
                         }?></pre>


### PR DESCRIPTION
When viewing a recipe, the full unit name used to be displayed. This change will use the abbreviation instead. 