### PR TITLE
Improved shopping list functionality - BUT.. For review only as some parts are hard coded

### DIFF
--- a/Locale/swe/LC_MESSAGES/default.po
+++ b/Locale/swe/LC_MESSAGES/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"PO-Revision-Date: 2017-02-01 21:19+0100\n"
+"PO-Revision-Date: 2017-03-26 18:25+0200\n"
 "Last-Translator: NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
 "MIME-Version: 1.0\n"
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 "POT-Creation-Date: \n"
 "Language: sv\n"
-"X-Generator: Poedit 1.8.11\n"
+"X-Generator: Poedit 1.8.12\n"
 
 #: Config/Schema/schema.php:19
 msgid "Beef"
@@ -444,19 +444,19 @@ msgstr "Gallon"
 
 #: Config/Schema/schema.php:176
 msgid "Milligram"
-msgstr "Milligram"
+msgstr "milligram"
 
 #: Config/Schema/schema.php:177
 msgid "Centigram"
-msgstr "Centigram"
+msgstr "centigram"
 
 #: Config/Schema/schema.php:178
 msgid "Gram"
-msgstr "Gram"
+msgstr "gram"
 
 #: Config/Schema/schema.php:179
 msgid "Kilogram"
-msgstr "Kilogram"
+msgstr "kilogram"
 
 #: Config/Schema/schema.php:180
 msgid "Milliliter"

--- a/Model/ShoppingList.php
+++ b/Model/ShoppingList.php
@@ -227,15 +227,15 @@ class ShoppingList extends AppModel {
 		
 		$volume = $this->volume();
 		$weight = $this->weight();
-		$actionToBeTaken = (isset($volume[$convert['targetUnitName']])) ? 'T' : 'F';
-		$actionToBeTaken .= (isset($weight[$convert['targetUnitName']])) ? 'T' : 'F';
-		$actionToBeTaken .= (isset($volume[$convert['unitName']])) ? 'T' : 'F';
-		$actionToBeTaken .= (isset($weight[$convert['unitName']])) ? 'T' : 'F';
+		$actionToBeTaken = (isset($volume[$convert['targetUnitId']])) ? 'T' : 'F';
+		$actionToBeTaken .= (isset($weight[$convert['targetUnitId']])) ? 'T' : 'F';
+		$actionToBeTaken .= (isset($volume[$convert['unitId']])) ? 'T' : 'F';
+		$actionToBeTaken .= (isset($weight[$convert['unitId']])) ? 'T' : 'F';
 				
 		switch ($actionToBeTaken) {
 			
 			case "TFTF":
-			$convert['quantity'] = $convert['quantity']*$volume[$convert['unitName']][$convert['targetUnitName']];
+			$convert['quantity'] = $convert['quantity']*$volume[$convert['unitId']][$convert['targetUnitId']];
 			break;
 			
 			//weight to volume
@@ -249,7 +249,7 @@ class ShoppingList extends AppModel {
 			break;
 			
 			case "FTFT":
-			$convert['quantity'] = $convert['quantity']*$weight[$convert['unitName']][$convert['targetUnitName']];
+			$convert['quantity'] = $convert['quantity']*$weight[$convert['unitId']][$convert['targetUnitId']];
 			break;
 			
 			default:
@@ -271,20 +271,20 @@ class ShoppingList extends AppModel {
 			$units = $correlations[$convert['ingredientName']];
 
 			//volume --> weight
-			if (isset($volume[$convert['unitName']])) {
+			if (isset($volume[$convert['unitId']])) {
 				$volumeUnit = $this->getConvertVolumeUnit($units, $volume);
-				$convert['quantity'] = $convert['quantity']*$volume[$convert['unitName']][$volumeUnit];
+				$convert['quantity'] = $convert['quantity']*$volume[$convert['unitId']][$volumeUnit];
 				$weightUnit = $this->getVolumeToWeight($units, $volume);
 				$convert['quantity'] = $convert['quantity']*$weightUnit['value'];
-				$convert['quantity'] = $convert['quantity']*$weight[$weightUnit['weightUnit']][$convert['targetUnitName']];
+				$convert['quantity'] = $convert['quantity']*$weight[$weightUnit['weightUnit']][$convert['targetUnitId']];
 			}
 			//weight --> volume
-			else if (isset($weight[$convert['unitName']])) {
+			else if (isset($weight[$convert['unitId']])) {
 				$weightUnit = $this->getConvertWeightUnit($units, $weight);
-				$convert['quantity'] = $convert['quantity']*$weight[$convert['unitName']][$weightUnit];
+				$convert['quantity'] = $convert['quantity']*$weight[$convert['unitId']][$weightUnit];
 				$volumeUnit = $this->getWeightToVolume($units, $weight);
 				$convert['quantity'] = $convert['quantity']*$volumeUnit['value'];
-				$convert['quantity'] = $convert['quantity']*$volume[$volumeUnit['volumeUnit']][$convert['targetUnitName']];
+				$convert['quantity'] = $convert['quantity']*$volume[$volumeUnit['volumeUnit']][$convert['targetUnitId']];
 			}
 		} 
 		else { //the correlations between volume and weight doesn't exist.
@@ -292,16 +292,16 @@ class ShoppingList extends AppModel {
 			switch($actionToBeTaken) {
 				case "TFFT":
 				//convert weight quantity to gram
-				$convert['quantity'] = $convert['quantity']*$weight[$convert['unitName']]['gram'];
+				$convert['quantity'] = $convert['quantity']*$weight[$convert['unitId']]['21'];
 				//convert gram=milliliter to target unit
-				$convert['quantity'] = $convert['quantity']*$volume['milliliter'][$convert['targetUnitName']];
+				$convert['quantity'] = $convert['quantity']*$volume['23'][$convert['targetUnitId']];
 				break;
 				
 				case "FTTF":
 				//convert volume quantity to millilitre
-				$convert['quantity'] = $convert['quantity']*$volume[$convert['unitName']]['milliliter'];
+				$convert['quantity'] = $convert['quantity']*$volume[$convert['unitId']]['23'];
 				//convert milliliter=gram to target unit
-				$convert['quantity'] = $convert['quantity']*$weight['gram'][$convert['targetUnitName']];
+				$convert['quantity'] = $convert['quantity']*$weight['21'][$convert['targetUnitId']];
 				break;
 				
 				default:
@@ -392,28 +392,28 @@ class ShoppingList extends AppModel {
 	private function correlationsArray() {
 		$correlations = array (
 			'vetemjöl' => array (
-				'gram' => 60,
-				'deciliter' => 1 
+				'21' => 60,
+				'26' => 1 
 			), 
 			'strösocker' => array (
-				'deciliter' => 1,
-				'gram' => 85
+				'26' => 1,
+				'21' => 85
 			),
 			'bacon' => array (
-				'deciliter' => 1,
-				'gram' => 34
+				'26' => 1,
+				'21' => 34
 			), 
 			'bakpulver' => array (
-				'deciliter' => 1,
-				'gram' => 5
+				'26' => 1,
+				'21' => 5
 			), 
 			'basmat ris' => array (
-				'deciliter' => 1,
-				'gram' => 85
+				'26' => 1,
+				'21' => 85
 			), 
 			'pasta' => array (
-				'deciliter' => 8,
-				'gram' => 280
+				'26' => 8,
+				'21' => 280
 			)
 			
 		);
@@ -425,97 +425,107 @@ class ShoppingList extends AppModel {
 	* Returns the matrix related to volumes. 
 	*/
 	private function volume() {		
-		$millilitre_msk = 1/15;
-		$tesked_msk = 5/15;
-		$centilitre_msk = 10/15;
-		$dl_msk = 100/15; 
-		$litre_msk = 1000/15;
+		$milliliter_tbsp = 1/15;
+		$tesked_tbsp = 5/15;
+		$centiliter_tbsp = 10/15;
+		$dl_tbps = 100/15; 
+		$liter_tbsp = 1000/15;
 		
-		
+		//29 = kryddmått
+		//23 = milliliter
+		//28 = teaspoon_m
+		//24 = centiliter
+		//27 = tablespoon_m 
+		//26 = deciliter
+		//25 = liter
 		$volumes = array(
-			'kryddmått' => array(
-				'kryddmått' => 1, 
-				'milliliter' => 1,
-				'tesked' => 0.2,
-				'centiliter' => 0.1, 
-				'matsked' => $millilitre_msk, 
-				'deciliter' => 0.01, 
-				'liter' => 0.001
+			'29' => array(
+				'29' => 1, 
+				'23' => 1,
+				'28' => 0.2,
+				'24' => 0.1, 
+				'27' => $milliliter_tbsp, 
+				'26' => 0.01, 
+				'25' => 0.001
 				), 
-			'milliliter' => array(
-				'kryddmått' => 1, 
-				'milliliter' => 1,
-				'tesked' => 0.2,
-				'centiliter' => 0.1, 
-				'matsked' => $millilitre_msk, 
-				'deciliter' => 0.01, 
-				'liter' => 0.001
+			'23' => array(
+				'29' => 1, 
+				'23' => 1,
+				'28' => 0.2,
+				'24' => 0.1, 
+				'27' => $milliliter_tbsp, 
+				'26' => 0.01, 
+				'25' => 0.001
 				), 
-			'tesked' => array(
-				'kryddmått' => 5, 
-				'milliliter' => 5,
-				'tesked' => 1,
-				'centiliter' => 0.5, 
-				'matsked' => $tesked_msk, 
-				'deciliter' => 0.05, 
-				'liter' => 0.005
+			'28' => array(
+				'29' => 5, 
+				'23' => 5,
+				'28' => 1,
+				'24' => 0.5, 
+				'27' => $tesked_tbsp, 
+				'26' => 0.05, 
+				'25' => 0.005
 				), 
-			'centiliter' => array(
-				'kryddmått' => 10, 
-				'milliliter' => 10,
-				'tesked' => 2,
-				'centiliter' => 1, 
-				'matsked' => $centilitre_msk, 
-				'deciliter' => 0.1, 
-				'liter' => 0.01
+			'24' => array(
+				'29' => 10, 
+				'23' => 10,
+				'28' => 2,
+				'24' => 1, 
+				'27' => $centiliter_tbsp, 
+				'26' => 0.1, 
+				'25' => 0.01
 				), 
-			'matsked' => array(
-				'kryddmått' => 15,
-				'milliliter' => 15,
-				'tesked' => 3,
-				'centiliter' => 1.5,
-				'matsked' => 1, 
-				'deciliter' => 0.15, 
-				'liter' => 0.015
+			'27' => array(
+				'29' => 15,
+				'23' => 15,
+				'28' => 3,
+				'24' => 1.5,
+				'27' => 1, 
+				'26' => 0.15, 
+				'25' => 0.015
 				), 
-			'deciliter' => array(
-				'kryddmått' => 100,
-				'milliliter' => 100,
-				'tesked' => 20,
-				'centiliter' => 10, 
-				'matsked' => $dl_msk, 
-				'deciliter' => 1, 
-				'liter' => 0.1
+			'26' => array(
+				'29' => 100,
+				'23' => 100,
+				'28' => 20,
+				'24' => 10, 
+				'27' => $dl_tbps, 
+				'26' => 1, 
+				'25' => 0.1
 				), 
-			'liter' => array(
-				'kryddmått' => 1000,
-				'milliliter' => 1000,
-				'tesked' => 200, 
-				'centiliter' => 100, 
-				'matsked' => $litre_msk, 
-				'deciliter' => 10, 
-				'liter' => 1
+			'25' => array(
+				'29' => 1000,
+				'23' => 1000,
+				'28' => 200, 
+				'24' => 100, 
+				'27' => $liter_tbsp, 
+				'26' => 10, 
+				'25' => 1
 				)
 			);
 		return $volumes;
 	}
 	
 	private function weight() {
+		
+		//21 = gram
+		//35 = hektogram
+		//22 = kilogram
 		$weights = array(
-			'gram' => array(
-				'gram' => 1, 
-				'hekto' => 0.01, 
-				'kilogram' => 0.001
+			'21' => array(
+				'21' => 1, 
+				'35' => 0.01, 
+				'22' => 0.001
 			), 
-			'hekto' => array(
-				'gram' => 100, 
-				'hekto' => 1, 
-				'kilogram' => 0.1
+			'35' => array(
+				'21' => 100, 
+				'35' => 1, 
+				'22' => 0.1
 			), 
-			'kilogram' => array(
-				'gram' => 1000, 
-				'hekto' => 10, 
-				'kilogram' => 1
+			'22' => array(
+				'21' => 1000, 
+				'35' => 10, 
+				'22' => 1
 			)
 		);
 		return $weights; 

--- a/View/ShoppingLists/select.ctp
+++ b/View/ShoppingLists/select.ctp
@@ -69,7 +69,7 @@
         
     <tr row-click>
         <td><input type="checkbox" name="remove[]" value="<?php echo $i . "-" . $j;?>" list-item/></td>
-        <td><?php echo $this->Fraction->toFraction($item->quantity);?></td>
+        <td><?php echo round($item->quantity, 1);?></td>
         <td><?php echo $item->unitName;?></td>
         <td><b><?php echo $item->name;?></b></td>
     </tr>


### PR DESCRIPTION
Hi, 
Please have a look at the improved shopping list functionality and guide me how we potentially can improve. 

What it does:
The shopping list will have an ingredient's unit displayed instead of the recipe's unit. 
Example:
* 1 deciliter of flour has a weight of 60 gram. 
* a recipe have 2 deciliter of flour
* the ingredient is said to be measured in kilogram. 
* the shopping list will display that you need to buy 0.1 kilogram of flour (2*60 gram  = 120 gram = 0.12 kilogram = rounded to 0.1 kilogram. 

Limitations:
* Only basic metric measurements are covered  in this version. Can easily be extended to cover US as well.
* Created private functions for "static data" - how to improve?
* Ingredients being converted are hard coded in Swedish - how to improve?
 