### PR TITLE
Force text field for username in login form

### DIFF
--- a/View/Users/login.ctp
+++ b/View/Users/login.ctp
@@ -11,7 +11,7 @@
         <legend>
             <?php echo __('Enter your username and password'); ?>
         </legend>
-        <?php echo $this->Form->input('username');
+        <?php echo $this->Form->input('username', array('type' => 'text'));
         echo $this->Form->input('password');
     ?>
     <?php echo $this->Html->link(__('Forgot password?'), array('action' => 'reset')); ?>   


### PR DESCRIPTION
The login form in my PHPRecipebook installation is being generated as a `textarea` rather than a regular input field (I suspect because I'm using PostgreSQL and the DB column is of type `text`).  This PR forces the helper to render a regular text field.