### PR TITLE
Add docker-support

### DIFF
--- a/.idea/sbt.xml
+++ b/.idea/sbt.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ScalaSbtSettings">
+    <option name="maximumHeapSize" value="1768" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ more effort copying files around.
 * Run `docker-compose up -d`
 * Execute `docker exec -ti docker_web_1  ./Console/cake schema create` and anser with `y`
 * Go to `http://localhost` and setup a user
-* Remove the possibility to run the setup by removing the comment sign `#` from the last line in `docker-compose.yml`
-* Restart the services to apply the change `docker-compose stop && docker-compose rm -f && docker up -d`
+* Remove the possibility to run the setup by removing the comment sign `#` from the last two lines in `docker-compose.yml`
+* Restart the services to apply the change `docker-compose stop && docker-compose rm -f && docker-compose up -d`
 
 The database is stored persistent in the folder dbdata. 
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ more effort copying files around.
 * Download latest release from https://github.com/nazgul26/PHPRecipebook/releases
 * Extract files to your web folder. 
 
+## docker-compse Install Option
+* Install git and docker-compose
+* Download git repository (e.g. with wget or git clone) or just download the docker folder
+* Change into directory `cd docker`
+* Run `docker-compose up -d`
+* Execute `docker exec -ti docker_web_1  ./Console/cake schema create` and anser with `y`
+* Go to `http://localhost` and setup a user
+* Remove the possibility to run the setup by removing the comment sign `#` from the last line in `docker-compose.yml`
+* Restart the services to apply the change `docker-compose stop && docker-compose rm -f && docker up -d`
+
+The database is stored persistent in the folder dbdata. 
+
 ## Setup Directions for all
 * Ensure you have the following PHP Modules installed: mcrypt, gd. And mysql, pgsql or your DB.
 * Create a new database to store the application in. i.e. recipebook

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,26 @@
+FROM php:7.0-apache
+
+ENV version 5.1.4
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN \
+  apt-get update && \
+  apt-get install -y wget mysql-client libmysqlclient-dev --no-install-recommends && \
+  docker-php-ext-install pdo pdo_mysql && \
+  a2enmod rewrite && \
+  apt-get -y autoremove && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+  cd /tmp && \
+  wget https://github.com/nazgul26/PHPRecipebook/releases/download/5.1.4/phprecipebook-${version}.tar.gz  --output-document="/tmp/phprecipebook-${version}.tar.gz"
+
+RUN \
+  cd /tmp && tar xf /tmp/phprecipebook-${version}.tar.gz && \
+  mv /tmp/phprecipebook/* /var/www/html && \
+  mv /tmp/phprecipebook/.htaccess /var/www/html
+
+COPY database.php /var/www/html/Config/database.php
+
+WORKDIR /var/www/html
+
+#USER www-data

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,5 +22,3 @@ RUN \
 COPY database.php /var/www/html/Config/database.php
 
 WORKDIR /var/www/html
-
-#USER www-data

--- a/docker/database.php
+++ b/docker/database.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ *
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       app.Config
+ * @since         CakePHP(tm) v 0.2.9
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Database configuration class.
+ *
+ * You can specify multiple configurations for production, development and testing.
+ *
+ * datasource => The name of a supported datasource; valid options are as follows:
+ *  Database/Mysql - MySQL 4 & 5,
+ *  Database/Sqlite - SQLite (PHP5 only),
+ *  Database/Postgres - PostgreSQL 7 and higher,
+ *  Database/Sqlserver - Microsoft SQL Server 2005 and higher
+ *
+ * You can add custom database datasources (or override existing datasources) by adding the
+ * appropriate file to app/Model/Datasource/Database. Datasources should be named 'MyDatasource.php',
+ *
+ *
+ * persistent => true / false
+ * Determines whether or not the database should use a persistent connection
+ *
+ * host =>
+ * the host you connect to the database. To add a socket or port number, use 'port' => #
+ *
+ * prefix =>
+ * Uses the given prefix for all the tables in this database. This setting can be overridden
+ * on a per-table basis with the Model::$tablePrefix property.
+ *
+ * schema =>
+ * For Postgres/Sqlserver specifies which schema you would like to use the tables in.
+ * Postgres defaults to 'public'. For Sqlserver, it defaults to empty and use
+ * the connected user's default schema (typically 'dbo').
+ *
+ * encoding =>
+ * For MySQL, Postgres specifies the character encoding to use when connecting to the
+ * database. Uses database default not specified.
+ *
+ * unix_socket =>
+ * For MySQL to connect via socket specify the `unix_socket` parameter instead of `host` and `port`
+ *
+ * settings =>
+ * Array of key/value pairs, on connection it executes SET statements for each pair
+ * For MySQL : http://dev.mysql.com/doc/refman/5.6/en/set-statement.html
+ * For Postgres : http://www.postgresql.org/docs/9.2/static/sql-set.html
+ * For Sql Server : http://msdn.microsoft.com/en-us/library/ms190356.aspx
+ */
+class DATABASE_CONFIG {
+
+	public $default = array(
+		'datasource' => 'Database/Mysql',
+		'persistent' => false,
+		'host' => 'localhost',
+		'login' => 'root',
+		'password' => '',
+		'database' => 'phprecipebook',
+		'prefix' => '',
+		//'encoding' => 'utf8',
+	);
+
+	public function __construct()
+	{
+		$this->default = array(
+			'datasource' => 'Database/Mysql',
+			'persistent' => false,
+			'host' => "db",
+			'login' => "phprecipebook",
+			'password' => "changeme-userpw",
+			'database' => "phprecipebook",
+			'prefix' => '',
+			'encoding' => 'utf8',
+		);
+	}
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.3'
+
+services:
+   db:
+     image: mysql:latest
+     volumes:
+       - ./dbdata:/var/lib/mysql
+     restart: always
+     environment:
+       MYSQL_ROOT_PASSWORD: "chanmgeme"
+       MYSQL_DATABASE: "phprecipebook"
+       MYSQL_USER: "phprecipebook"
+       MYSQL_PASSWORD: "changeme-userpw"
+
+
+   web:
+     depends_on:
+       - db
+     build: .
+     ports:
+       - "80:80"
+     restart: always
+     volumes:
+#      - /tmp/SetupController:/var/www/html/Controller/SetupController.php

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,5 +20,5 @@ services:
      ports:
        - "80:80"
      restart: always
-     volumes:
+#     volumes:
 #      - /tmp/SetupController:/var/www/html/Controller/SetupController.php


### PR DESCRIPTION
Add support for docker.

The following tasks are for future purpose:
- Run container as user www-data (USER www-data is not working, investigation needed)
- Add support to have default Database-Configuration and grab all parameters from environment for full configuration through docker-compose
- Use "COPY" instead of fetching the tar.gz to support a better build process. I had complications with cakePHP-Setup and run in docker