### PR TITLE
Fix fra locales: '%s' was '% s'

### DIFF
--- a/Locale/fra/LC_MESSAGES/cake.po
+++ b/Locale/fra/LC_MESSAGES/cake.po
@@ -16,7 +16,7 @@ msgstr "Erreur"
 
 #: View/Errors/error400.ctp:23
 msgid "The requested address %s was not found on this server."
-msgstr "L&#39;adresse demandée% s n&#39;a pas été trouvé sur ce serveur."
+msgstr "L&#39;adresse demandée %s n&#39;a pas été trouvé sur ce serveur."
 
 #: View/Errors/error500.ctp:22
 msgid "An Internal Error Has Occurred."

--- a/Locale/fra/LC_MESSAGES/default.po
+++ b/Locale/fra/LC_MESSAGES/default.po
@@ -1015,7 +1015,7 @@ msgstr "DEFAULT"
 
 #: Plugin/Upload/Model/Behavior/UploadBehavior.php:1078
 msgid "No filename after parsing. Function %s returned an invalid filename"
-msgstr "Pas de nom de fichier après l&#39;analyse. Fonction% s retourné un nom de fichier non valide"
+msgstr "Pas de nom de fichier après l&#39;analyse. Fonction %s retourné un nom de fichier non valide"
 
 #: View/BaseTypes/edit.ctp:12
 #: View/CoreIngredients/edit.ctp:14
@@ -1122,7 +1122,7 @@ msgstr "Effacer"
 #: View/Recipes/index.ctp:92
 #: View/Sources/index.ctp:27
 msgid "Are you sure you want to delete %s?"
-msgstr "Êtes-vous sûr de vouloir supprimer% s?"
+msgstr "Êtes-vous sûr de vouloir supprimer %s?"
 
 #: View/BaseTypes/index.ctp:32
 #: View/CoreIngredients/index.ctp:43
@@ -1202,7 +1202,7 @@ msgstr "Liste Ingrédients"
 #: View/Users/index.ctp:26
 #: View/Users/view.ctp:5
 msgid "Are you sure you want to delete # %s?"
-msgstr "Êtes-vous sûr de vouloir supprimer #% s?"
+msgstr "Êtes-vous sûr de vouloir supprimer # %s?"
 
 #: View/Courses/index.ctp:10
 msgid "Courses"
@@ -1289,7 +1289,7 @@ msgstr "Ajouter Unité"
 #: View/Ingredients/index.ctp:54
 #: View/Locations/index.ctp:27
 msgid "Are you sure you want to delete \"%s\"?"
-msgstr "Etes-vous sûr de vouloir supprimer &quot;% s&quot;?"
+msgstr "Etes-vous sûr de vouloir supprimer \"%s\"?"
 
 #: View/Layouts/default.ctp:57
 msgid "Browse your recipes"
@@ -1474,7 +1474,7 @@ msgstr "Aujourd&#39;hui"
 
 #: View/MealPlans/index.ctp:64
 msgid "Are you sure you want to delete meal \"%s\"?"
-msgstr "Etes-vous sûr de vouloir supprimer repas &quot;% s&quot;?"
+msgstr "Etes-vous sûr de vouloir supprimer repas \"%s\"?"
 
 #: View/PreparationMethods/index.ctp:11
 msgid "Preparation Methods"
@@ -1774,7 +1774,7 @@ msgstr "Portions acheter"
 
 #: View/ShoppingLists/index.ctp:107;143
 msgid "Are you sure you want to remove %s?"
-msgstr "Êtes-vous sûr de vouloir supprimer% s?"
+msgstr "Êtes-vous sûr de vouloir supprimer %s?"
 
 #: View/ShoppingLists/index.ctp:130
 msgid "Ingredient Name"

--- a/Locale/fra/LC_MESSAGES/setup.po
+++ b/Locale/fra/LC_MESSAGES/setup.po
@@ -110,11 +110,11 @@ msgstr "Votre répertoire TMP ne est pas accessible en écriture."
 
 #: View/Setup/index.ctp:50
 msgid "The %s is being used for core caching. To change the config edit %s"
-msgstr "Le% s est utilisée pour la mise en cache de base. Pour changer la config modifier% s"
+msgstr "Le %s est utilisée pour la mise en cache de base. Pour changer la config modifier %s"
 
 #: View/Setup/index.ctp:54
 msgid "Your cache is NOT working. Please check the settings in %s"
-msgstr "Votre cache ne fonctionne pas. Se il vous plaît vérifier les paramètres en% s"
+msgstr "Votre cache ne fonctionne pas. Se il vous plaît vérifier les paramètres en %s"
 
 #: View/Setup/index.ctp:64
 msgid "Your database configuration file is present."
@@ -126,7 +126,7 @@ msgstr "Votre fichier de configuration de base de données ne est pas présent."
 
 #: View/Setup/index.ctp:71
 msgid "Rename %s to %s"
-msgstr "Renommez% s à% s"
+msgstr "Renommez %s à %s"
 
 #: View/Setup/index.ctp:96
 msgid "CakePHP is able to connect to the database."


### PR DESCRIPTION
All the `%s` in the fra locale files where changed to `% s` leading to incorrect messages being displayed.