### PR TITLE
Adding logic to allow the "last_login" field to work correctly

### DIFF
--- a/Controller/UsersController.php
+++ b/Controller/UsersController.php
@@ -53,6 +53,13 @@ class UsersController extends AppController {
                         $this->Session->write('Config.language', $item['User']['language']);
                     }
                     
+                    $this->User->id = $this->Auth->user('id');
+                    $this->User->read();
+                    $this->User->data['User']['last_login'] = date('Y-m-d H:i:s');
+                    $this->User->data['User']['modified'] = false; //don't update the modified field
+		            $this->User->save($this->User->data);
+
+
                     $redirectUrl = $this->Auth->redirectUrl();
                     if ($this->String->endsWith($redirectUrl, '/Users/login')) {
                         return $this->redirect(array('controller' => 'recipes', 'action' => 'index'));

--- a/Model/User.php
+++ b/Model/User.php
@@ -50,8 +50,13 @@ class User extends AppModel {
         ),
     );
     
+    public function startsWith( $haystack, $needle ) {
+        $length = strlen( $needle );
+        return substr( $haystack, 0, $length ) === $needle;
+    }
+   
     public function beforeSave($options = array()) {
-        if (isset($this->data[$this->alias]['password'])) {
+        if (isset($this->data[$this->alias]['password']) && !$this->startsWith($this->data[$this->alias]['password'],'$2a')) {
             $passwordHasher = new BlowfishPasswordHasher();
             $this->data[$this->alias]['password'] = $passwordHasher->hash(
                 $this->data[$this->alias]['password']

--- a/View/Users/edit.ctp
+++ b/View/Users/edit.ctp
@@ -38,7 +38,7 @@
                     );
             echo $this->Form->input('language', array('options' => Configure::read('Languages')));
             echo $this->Form->input('country');
-            echo $this->Form->input('last_login',array('disabled' => 'disabled'));
+            echo $this->Form->input('last_login (UTC)',array('disabled' => 'disabled'));
             
 	?>
 	</fieldset>

--- a/View/Users/index.ctp
+++ b/View/Users/index.ctp
@@ -12,9 +12,9 @@
             <th><?php echo $this->Paginator->sort('name'); ?></th>
             <th><?php echo $this->Paginator->sort('email'); ?></th>
             <th><?php echo $this->Paginator->sort('access_level'); ?></th>
-            <th><?php echo $this->Paginator->sort('last_login'); ?></th>
-            <th><?php echo $this->Paginator->sort('created'); ?></th>
-            <th><?php echo $this->Paginator->sort('modified'); ?></th>
+            <th><?php echo $this->Paginator->sort('last_login (UTC)'); ?></th>
+            <th><?php echo $this->Paginator->sort('created (UTC)'); ?></th>
+            <th><?php echo $this->Paginator->sort('modified (UTC)'); ?></th>
 	</tr>
 	<?php foreach ($users as $user): ?>
 	<tr>

--- a/View/Users/view.ctp
+++ b/View/Users/view.ctp
@@ -38,12 +38,12 @@
 			<?php echo h($user['User']['country']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Created'); ?></dt>
+		<dt><?php echo __('Created (UTC)'); ?></dt>
 		<dd>
 			<?php echo h($user['User']['created']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Last Login'); ?></dt>
+		<dt><?php echo __('Last Login (UTC)'); ?></dt>
 		<dd>
 			<?php echo h($user['User']['last_login']); ?>
 			&nbsp;
@@ -53,7 +53,7 @@
 			<?php echo h($user['User']['email']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Modified'); ?></dt>
+		<dt><?php echo __('Modified (UTC)'); ?></dt>
 		<dd>
 			<?php echo h($user['User']['modified']); ?>
 			&nbsp;


### PR DESCRIPTION
This was bugging me that the last_login field on the users page didn't work.  This adds logic to the login function to write the current UTC date to the last_login field without updating the modified field.  I also had to update the User::beforeSave function to not generate a hash of the password if the password starts with '$2a'.  This would have to change if the hash generated by the blowfish hasher changes.  At least on my server the every password started with that string.

I mangled at least two user account passwords on my server before I realized what was going on. (Think god for database backups).