### PR TITLE
Update DefaultPasswordHasher import in seeding code (issue #171)

### DIFF
--- a/config/Seeds/UsersSeed.php
+++ b/config/Seeds/UsersSeed.php
@@ -1,6 +1,6 @@
 <?php
 use Migrations\AbstractSeed;
-use Cake\Auth\DefaultPasswordHasher;
+use Authentication\PasswordHasher\DefaultPasswordHasher;
 
 /**
  * Users seed.


### PR DESCRIPTION
This PR updates the import of `DefaultPasswordHasher` in the seeding code for compatibility with the current version of CakePHP.  It resolves issue #171 