### PR TITLE
Fix migration to also work with PostgreSQL (issue #170)

### DIFF
--- a/config/Migrations/20210101154551_Initial.php
+++ b/config/Migrations/20210101154551_Initial.php
@@ -362,7 +362,7 @@ class Initial extends AbstractMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addColumn('picture', 'blob', [
+            ->addColumn('picture', 'binary', [
                 'default' => null,
                 'null' => true,
             ])
@@ -457,7 +457,7 @@ class Initial extends AbstractMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addColumn('picture', 'blob', [
+            ->addColumn('picture', 'binary', [
                 'default' => null,
                 'null' => true,
             ])


### PR DESCRIPTION
This PR patches the use in the migrations of the mysql `blob` type, replacing it with `binary`.  This change makes the migrations compatible with both MySQL and PostgreSQL, and resolves issue #170 