### PR TITLE
Use array form for SQL query parameters

### DIFF
--- a/src/Controller/BaseTypesController.php
+++ b/src/Controller/BaseTypesController.php
@@ -17,14 +17,14 @@ class BaseTypesController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->BaseTypes->exists($id)) {
+        if ($id != null && !$this->BaseTypes->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid base type'));
         }
 
         if ($id == null) {
             $baseType = $this->BaseTypes->newEmptyEntity();
         } else {
-            $baseType = $this->BaseTypes->get($id);
+            $baseType = $this->BaseTypes->get(['id' => $id]);
         }
 
         if ($this->request->is(['patch', 'post', 'put'])) {
@@ -44,7 +44,7 @@ class BaseTypesController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $baseType = $this->BaseTypes->get($id);
+        $baseType = $this->BaseTypes->get(['id' => $id]);
         if ($this->BaseTypes->delete($baseType)) {
             $this->Flash->success(__('The base type has been deleted.'));
         } else {

--- a/src/Controller/CoursesController.php
+++ b/src/Controller/CoursesController.php
@@ -18,14 +18,14 @@ class CoursesController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->Courses->exists($id)) {
+        if ($id != null && !$this->Courses->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid base type'));
         }
 
         if ($id == null) {
             $course = $this->Courses->newEmptyEntity();
         } else {
-            $course = $this->Courses->get($id);
+            $course = $this->Courses->get(['id' => $id]);
         }
 
         if ($this->request->is(['patch', 'post', 'put'])) {
@@ -45,7 +45,7 @@ class CoursesController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $course = $this->Courses->get($id);
+        $course = $this->Courses->get(['id' => $id]);
         if ($this->Courses->delete($course)) {
             $this->Flash->success(__('The course has been deleted.'));
         } else {

--- a/src/Controller/DifficultiesController.php
+++ b/src/Controller/DifficultiesController.php
@@ -17,14 +17,14 @@ class DifficultiesController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->Difficulties->exists($id)) {
+        if ($id != null && !$this->Difficulties->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid base type'));
         }
 
         if ($id == null) {
             $difficulty = $this->Difficulties->newEmptyEntity();
         } else {
-            $difficulty = $this->Difficulties->get($id);
+            $difficulty = $this->Difficulties->get(['id' => $id]);
         }
 
         if ($this->request->is(['patch', 'post', 'put'])) {
@@ -44,7 +44,7 @@ class DifficultiesController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $difficulty = $this->Difficulties->get($id);
+        $difficulty = $this->Difficulties->get(['id' => $id]);
         if ($this->Difficulties->delete($difficulty)) {
             $this->Flash->success(__('The difficulty has been deleted.'));
         } else {

--- a/src/Controller/EthnicitiesController.php
+++ b/src/Controller/EthnicitiesController.php
@@ -17,14 +17,14 @@ class EthnicitiesController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->Ethnicities->exists($id)) {
+        if ($id != null && !$this->Ethnicities->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid ethnicity type'));
         }
 
         if ($id == null) {
             $ethnicity = $this->Ethnicities->newEmptyEntity();
         } else {
-            $ethnicity = $this->Ethnicities->get($id);
+            $ethnicity = $this->Ethnicities->get(['id' => $id]);
         }
 
         if ($this->request->is(['patch', 'post', 'put'])) {
@@ -44,7 +44,7 @@ class EthnicitiesController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $ethnicity = $this->Ethnicities->get($id);
+        $ethnicity = $this->Ethnicities->get(['id' => $id]);
         if ($this->Ethnicities->delete($ethnicity)) {
             $this->Flash->success(__('The ethnicity has been deleted.'));
         } else {

--- a/src/Controller/IngredientsController.php
+++ b/src/Controller/IngredientsController.php
@@ -56,14 +56,14 @@ class IngredientsController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->Ingredients->exists($id)) {
+        if ($id != null && !$this->Ingredients->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid ingredient type'));
         }
 
         if ($id == null) {
             $ingredient = $this->Ingredients->newEmptyEntity();
         } else {
-            $ingredient = $this->Ingredients->get($id);
+            $ingredient = $this->Ingredients->get(['id' => $id]);
         }
 
         if ($this->request->is(['patch', 'post', 'put'])) {
@@ -88,7 +88,7 @@ class IngredientsController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $ingredient = $this->Ingredients->get($id);
+        $ingredient = $this->Ingredients->get(['id' => $id]);
         if ($this->Ingredients->delete($ingredient)) {
             $this->Flash->success(__('The ingredient has been deleted.'));
         } else {

--- a/src/Controller/LocationsController.php
+++ b/src/Controller/LocationsController.php
@@ -21,14 +21,14 @@ class LocationsController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->Locations->exists($id)) {
+        if ($id != null && !$this->Locations->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid base type'));
         }
 
         if ($id == null) {
             $location = $this->Locations->newEmptyEntity();
         } else {
-            $location = $this->Locations->get($id);
+            $location = $this->Locations->get(['id' => $id]);
         }
 
         if ($this->request->is(['patch', 'post', 'put'])) {
@@ -47,7 +47,7 @@ class LocationsController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $location = $this->Locations->get($id);
+        $location = $this->Locations->get(['id' => $id]);
         if ($this->Locations->delete($location)) {
             $this->Flash->success(__('The location has been deleted.'));
         } else {

--- a/src/Controller/MealPlansController.php
+++ b/src/Controller/MealPlansController.php
@@ -106,7 +106,7 @@ class MealPlansController extends AppController
     {
         if ($id == "undefined") $id = null;
 
-        if ($id != null && !$this->MealPlans->exists($id)) {
+        if ($id != null && !$this->MealPlans->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid meal plan'));
         }
 
@@ -161,7 +161,7 @@ class MealPlansController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $mealPlan = $this->MealPlans->get($id);
+        $mealPlan = $this->MealPlans->get(['id' => $id]);
         if ($this->MealPlans->delete($mealPlan)) {
             $this->Flash->success(__('The meal plan has been deleted.'));
         } else {

--- a/src/Controller/PreparationMethodsController.php
+++ b/src/Controller/PreparationMethodsController.php
@@ -19,14 +19,14 @@ class PreparationMethodsController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->PreparationMethods->exists($id)) {
+        if ($id != null && !$this->PreparationMethods->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid base type'));
         }
 
         if ($id == null) {
             $preparationMethod = $this->PreparationMethods->newEmptyEntity();
         } else {
-            $preparationMethod = $this->PreparationMethods->get($id);
+            $preparationMethod = $this->PreparationMethods->get(['id' => $id]);
         }
 
         if ($this->request->is(['patch', 'post', 'put'])) {
@@ -45,7 +45,7 @@ class PreparationMethodsController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $preparationMethod = $this->PreparationMethods->get($id);
+        $preparationMethod = $this->PreparationMethods->get(['id' => $id]);
         if ($this->PreparationMethods->delete($preparationMethod)) {
             $this->Flash->success(__('The preparation method has been deleted.'));
         } else {

--- a/src/Controller/PreparationTimesController.php
+++ b/src/Controller/PreparationTimesController.php
@@ -17,14 +17,14 @@ class PreparationTimesController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->PreparationTimes->exists($id)) {
+        if ($id != null && !$this->PreparationTimes->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid base type'));
         }
 
         if ($id == null) {
             $preparationTime = $this->PreparationTimes->newEmptyEntity();
         } else {
-            $preparationTime = $this->PreparationTimes->get($id);
+            $preparationTime = $this->PreparationTimes->get(['id' => $id]);
         }
 
         if ($this->request->is(['patch', 'post', 'put'])) {
@@ -43,7 +43,7 @@ class PreparationTimesController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $preparationTime = $this->PreparationTimes->get($id);
+        $preparationTime = $this->PreparationTimes->get(['id' => $id]);
         if ($this->PreparationTimes->delete($preparationTime)) {
             $this->Flash->success(__('The preparation time has been deleted.'));
         } else {

--- a/src/Controller/PriceRangesController.php
+++ b/src/Controller/PriceRangesController.php
@@ -25,14 +25,14 @@ class PriceRangesController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->PriceRanges->exists($id)) {
+        if ($id != null && !$this->PriceRanges->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid price range'));
         }
 
         if ($id == null) {
             $priceRange = $this->PriceRanges->newEmptyEntity();
         } else {
-            $priceRange = $this->PriceRanges->get($id);
+            $priceRange = $this->PriceRanges->get(['id' => $id]);
         }
 
         if ($this->request->is(['patch', 'post', 'put'])) {
@@ -51,7 +51,7 @@ class PriceRangesController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $priceRange = $this->PriceRanges->get($id);
+        $priceRange = $this->PriceRanges->get(['id' => $id]);
         if ($this->PriceRanges->delete($priceRange)) {
             $this->Flash->success(__('The price range has been deleted.'));
         } else {

--- a/src/Controller/RecipesController.php
+++ b/src/Controller/RecipesController.php
@@ -128,7 +128,7 @@ class RecipesController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->Recipes->exists($id)) {
+        if ($id != null && !$this->Recipes->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid price range'));
         }
 
@@ -216,7 +216,7 @@ class RecipesController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $recipe = $this->Recipes->get($id);
+        $recipe = $this->Recipes->get(['id' => $id]);
         if ($this->Recipes->delete($recipe)) {
             $this->Flash->success(__('The recipe has been deleted.'));
         } else {
@@ -248,7 +248,7 @@ class RecipesController extends AppController
 
     public function deleteAttachment($recipeId, $id)
     {
-        $image = $this->Recipes->Attachments->get($id);
+        $image = $this->Recipes->Attachments->get(['id' => $id]);
         if ($this->Recipes->Attachments->delete($image)) {
             $this->Flash->success(__('The image has been removed.'));
         } else {

--- a/src/Controller/RestaurantsController.php
+++ b/src/Controller/RestaurantsController.php
@@ -28,7 +28,7 @@ class RestaurantsController extends AppController
 
     public function edit($id = null)
     {
-        $restaurant = $this->Restaurants->get($id);
+        $restaurant = $this->Restaurants->get(['id' => $id]);
         if ($this->request->is(['patch', 'post', 'put'])) {
             $restaurant = $this->Restaurants->patchEntity($restaurant, $this->request->getData());
             if ($this->Restaurants->save($restaurant)) {
@@ -46,7 +46,7 @@ class RestaurantsController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $restaurant = $this->Restaurants->get($id);
+        $restaurant = $this->Restaurants->get(['id' => $id]);
         if ($this->Restaurants->delete($restaurant)) {
             $this->Flash->success(__('The restaurant has been deleted.'));
         } else {

--- a/src/Controller/ReviewsController.php
+++ b/src/Controller/ReviewsController.php
@@ -64,7 +64,7 @@ class ReviewsController extends AppController
         if ($recipeId == null) {
             throw new NotFoundException(__('Missing recipe ID'));
         }
-        if ($id != null && !$this->Reviews->exists($id)) {
+        if ($id != null && !$this->Reviews->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid review'));
         }
 
@@ -103,7 +103,7 @@ class ReviewsController extends AppController
     public function delete($recipeId = null, $id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $review = $this->Reviews->get($id);
+        $review = $this->Reviews->get(['id' => $id]);
         if ($this->Reviews->delete($review)) {
             $this->Flash->success(__('The review has been deleted.'));
         } else {

--- a/src/Controller/ShoppingListsController.php
+++ b/src/Controller/ShoppingListsController.php
@@ -43,7 +43,7 @@ class ShoppingListsController extends AppController
 
     public function index($id = null)
     {
-        if ($id != null && !$this->ShoppingLists->exists($id)) {
+        if ($id != null && !$this->ShoppingLists->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid shopping list'));
         }
         if ($this->request->is(array('post', 'put'))) {

--- a/src/Controller/SourcesController.php
+++ b/src/Controller/SourcesController.php
@@ -19,14 +19,14 @@ class SourcesController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->Sources->exists($id)) {
+        if ($id != null && !$this->Sources->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid price range'));
         }
 
         if ($id == null) {
             $source = $this->Sources->newEmptyEntity();
         } else {
-            $source = $this->Sources->get($id);
+            $source = $this->Sources->get(['id' => $id]);
         }
 
         if ($this->request->is(['patch', 'post', 'put'])) {
@@ -46,7 +46,7 @@ class SourcesController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $source = $this->Sources->get($id);
+        $source = $this->Sources->get(['id' => $id]);
         if ($this->Sources->delete($source)) {
             $this->Flash->success(__('The source has been deleted.'));
         } else {

--- a/src/Controller/StoresController.php
+++ b/src/Controller/StoresController.php
@@ -17,14 +17,14 @@ class StoresController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->Stores->exists($id)) {
+        if ($id != null && !$this->Stores->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid store'));
         }
 
         if ($id == null) {
             $store = $this->Stores->newEmptyEntity();
         } else {
-            $store = $this->Stores->get($id);
+            $store = $this->Stores->get(['id' => $id]);
         }
 
         if ($this->request->is(['patch', 'post', 'put'])) {
@@ -43,7 +43,7 @@ class StoresController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $store = $this->Stores->get($id);
+        $store = $this->Stores->get(['id' => $id]);
         if ($this->Stores->delete($store)) {
             $this->Flash->success(__('The store has been deleted.'));
         } else {

--- a/src/Controller/TagsController.php
+++ b/src/Controller/TagsController.php
@@ -52,14 +52,14 @@ class TagsController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->Tags->exists($id)) {
+        if ($id != null && !$this->Tags->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid tag'));
         }
 
         if ($id == null) {
             $tag = $this->Tags->newEmptyEntity();
         } else {
-            $tag = $this->Tags->get($id);
+            $tag = $this->Tags->get(['id' => $id]);
         }
 
         if ($this->request->is(['patch', 'post', 'put'])) {
@@ -80,7 +80,7 @@ class TagsController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $tag = $this->Tags->get($id);
+        $tag = $this->Tags->get(['id' => $id]);
         if ($this->Tags->delete($tag)) {
             $this->Flash->success(__('The tag has been deleted.'));
         } else {

--- a/src/Controller/UnitsController.php
+++ b/src/Controller/UnitsController.php
@@ -19,14 +19,14 @@ class UnitsController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->Units->exists($id)) {
+        if ($id != null && !$this->Units->exists(['id' => $id])) {
             throw new NotFoundException(__('Invalid unit'));
         }
 
         if ($id == null) {
             $unit = $this->Units->newEmptyEntity();
         } else {
-            $unit = $this->Units->get($id);
+            $unit = $this->Units->get(['id' => $id]);
         }
 
         if ($this->request->is(['patch', 'post', 'put'])) {
@@ -45,7 +45,7 @@ class UnitsController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $unit = $this->Units->get($id);
+        $unit = $this->Units->get(['id' => $id]);
         if ($this->Units->delete($unit)) {
             $this->Flash->success(__('The unit has been deleted.'));
         } else {

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -151,7 +151,7 @@ class UsersController extends AppController
 
     public function edit($id = null)
     {
-        $user = $this->Users->get($id);
+        $user = $this->Users->get(['id' => $id]);
         if ($this->request->is(['patch', 'post', 'put'])) {
             $data = $this->request->getData();
             if ($data['password1'] === $data['password2']) {
@@ -249,7 +249,7 @@ class UsersController extends AppController
     public function delete($id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $user = $this->Users->get($id);
+        $user = $this->Users->get(['id' => $id]);
         if ($this->Users->delete($user)) {
             $this->Flash->success(__('The user has been deleted.'));
         } else {


### PR DESCRIPTION
My deployment of PHPRecipebook, which uses PostgreSQL, was raising exception in certain circumstances, such as when opening a recipe for editing:  see issue #189.

The problem seems to be solved by passing an array to specify SQL query parameters.  I ran a quick `find` + `sed` command to substitute all occurrences of `($id)` with `['id' => $id]`, which seems to have fixed the problem.  This PR is the resulting patch.