### PR TITLE
Turn off browser autocomplete on ingredient name field

### DIFF
--- a/templates/Recipes/edit.php
+++ b/templates/Recipes/edit.php
@@ -169,7 +169,7 @@ $baseUrl = Router::url('/');
                         <?= $this->Form->control('ingredient_mappings.' . $mapIndex . '.quantity', ['label' => false, 'type' => 'fraction']) ?></td>
                     <td><?= $this->Form->control('ingredient_mappings.' . $mapIndex . '.unit_id', ['label' => false]) ?></td>
                     <td><?= $this->Form->control('ingredient_mappings.' . $mapIndex . '.qualifier', ['label' => false, 'escape' => false]) ?></td>
-                    <td><?= $this->Form->control('ingredient_mappings.' . $mapIndex . '.ingredient.name', ['label' => false, 'escape' => false, 'type' => 'ui-widget']) ?></td>
+                    <td><?= $this->Form->control('ingredient_mappings.' . $mapIndex . '.ingredient.name', ['label' => false, 'escape' => false, 'type' => 'ui-widget', 'autocomplete' => 'off']) ?></td>
                     <td><?= $this->Form->control('ingredient_mappings.' . $mapIndex . '.optional', ['label' => false]) ?></td>
                 </tr>
                 <?php } ?>


### PR DESCRIPTION
This change avoids having the browser autocompletion conflict with the applications.  Solves issue #194.
