### PR TITLE
Recipe → ingredients view: apply autocomplete to new rows

### DIFF
--- a/src/Controller/RecipesController.php
+++ b/src/Controller/RecipesController.php
@@ -128,8 +128,8 @@ class RecipesController extends AppController
 
     public function edit($id = null)
     {
-        if ($id != null && !$this->Recipes->exists($id)) {
-            throw new NotFoundException(__('Invalid price range'));
+        if ($id != null && !$this->Recipes->exists(['id' => $id])) {
+            throw new NotFoundException(__('Recipe ID not found'));
         }
 
         if ($id == null) {

--- a/templates/Recipes/edit.php
+++ b/templates/Recipes/edit.php
@@ -683,7 +683,7 @@ $baseUrl = Router::url('/');
             findInputFilter = "input[id$=-ingredient_id]";
         }
 
-        document.querySelectorAll(sectionId + " input[type='ui-widget']").forEach(function(inp) {
+        document.querySelectorAll(sectionId + " input[name$='[name]']").forEach(function(inp) {
             if (inp._autocompleteInit) return;
             inp._autocompleteInit = true;
             inp.type = 'text';


### PR DESCRIPTION
This PR changes the field selector use to select the input fields on which autocomplete is initialized so that the dynamically created ingredient name fields are included.
    
Fixes issue #195.