### PR TITLE
In the Recipes edit form, set focus on newly created ingredients row

### DIFF
--- a/templates/Recipes/edit.php
+++ b/templates/Recipes/edit.php
@@ -364,10 +364,15 @@ $baseUrl = Router::url('/');
 
         document.getElementById('AddMoreIngredientsLink')?.addEventListener('click', function(e) {
             e.preventDefault();
-            var extras = document.querySelectorAll('#ingredientsSection .extraItem input');
+            var extraRow = document.querySelector('#ingredientsSection .extraItem');
+            var extras = extraRow ? extraRow.querySelectorAll('input') : [];
             extras.forEach(function(inp) {
                 inp.dispatchEvent(new Event('change', { bubbles: true }));
             });
+            if (extraRow) {
+                var qtyInput = extraRow.querySelector('input[name$="[quantity]"]');
+                if (qtyInput) qtyInput.focus();
+            }
         });
 
         document.getElementById('AddMoreRelatedRecipesLink')?.addEventListener('click', function(e) {


### PR DESCRIPTION
With this change, the new ingredient row created while editing recipes (by pressing the "Add New Ingredient" button) automatically gets the input focus.  This allows one to easily type in all ingredients without using the mouse.